### PR TITLE
Accept subclasses

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -18,7 +18,7 @@ API GatewayでREST APIを記述するとき、私はいつもCORSを扱うため
 このレポジトリをNodeの依存関係に追加してください。
 
 ```sh
-npm install https://github.com/codemonger-io/cdk-cors-utils.git#v0.1.0
+npm install https://github.com/codemonger-io/cdk-cors-utils.git#v0.2.0
 ```
 
 インストールしたモジュールは`cdk2-cors-utils`として以下のように利用できます。

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ These functions are quite simple though, I no longer want to prepare them everyt
 Please add this repository to your Node dependencies.
 
 ```sh
-npm install https://github.com/codemonger-io/cdk-cors-utils.git#v0.1.0
+npm install https://github.com/codemonger-io/cdk-cors-utils.git#v0.2.0
 ```
 
 The installed module will be available as `cdk2-cors-utils` like the following,

--- a/api-docs/cdk2-cors-utils.api.md
+++ b/api-docs/cdk2-cors-utils.api.md
@@ -7,9 +7,9 @@
 import { aws_apigateway } from 'aws-cdk-lib';
 
 // @beta
-export function makeIntegrationResponsesAllowCors(responses: aws_apigateway.IntegrationResponse[]): aws_apigateway.IntegrationResponse[];
+export function makeIntegrationResponsesAllowCors<T extends aws_apigateway.IntegrationResponse>(responses: T[]): T[];
 
 // @beta
-export function makeMethodResponsesAllowCors(responses: aws_apigateway.MethodResponse[]): aws_apigateway.MethodResponse[];
+export function makeMethodResponsesAllowCors<T extends aws_apigateway.MethodResponse>(responses: T[]): T[];
 
 ```

--- a/api-docs/markdown/cdk2-cors-utils.makeintegrationresponsesallowcors.md
+++ b/api-docs/markdown/cdk2-cors-utils.makeintegrationresponsesallowcors.md
@@ -12,22 +12,24 @@ Makes given [IntegrationResponse](https://docs.aws.amazon.com/cdk/api/v2/docs/aw
 <b>Signature:</b>
 
 ```typescript
-export declare function makeIntegrationResponsesAllowCors(responses: apigateway.IntegrationResponse[]): apigateway.IntegrationResponse[];
+export declare function makeIntegrationResponsesAllowCors<T extends apigateway.IntegrationResponse>(responses: T[]): T[];
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  responses | apigateway.IntegrationResponse\[\] | Integration response settings to allow CORS. |
+|  responses | T\[\] | Integration response settings to allow CORS. |
 
 <b>Returns:</b>
 
-apigateway.IntegrationResponse\[\]
+T\[\]
 
 `responses` with updated [responseParameters](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.IntegrationResponse.html#responseparameters)<!-- -->.
 
 ## Remarks
+
+This function accepts any subclass `T` of [aws\_apigateway.IntegrationResponse](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.IntegrationResponse.html)<!-- -->.
 
 Configures the following response headers,
 

--- a/api-docs/markdown/cdk2-cors-utils.makemethodresponsesallowcors.md
+++ b/api-docs/markdown/cdk2-cors-utils.makemethodresponsesallowcors.md
@@ -12,22 +12,24 @@ Makes given [MethodResponse](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk
 <b>Signature:</b>
 
 ```typescript
-export declare function makeMethodResponsesAllowCors(responses: apigateway.MethodResponse[]): apigateway.MethodResponse[];
+export declare function makeMethodResponsesAllowCors<T extends apigateway.MethodResponse>(responses: T[]): T[];
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  responses | apigateway.MethodResponse\[\] | Method response settings to allow CORS. |
+|  responses | T\[\] | Method response settings to allow CORS. |
 
 <b>Returns:</b>
 
-apigateway.MethodResponse\[\]
+T\[\]
 
 `responses` with updated [responseParameters](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.MethodResponse.html#responseparameters)<!-- -->.
 
 ## Remarks
+
+This function accepts any subclass `T` of [aws\_apigateway.MethodResponse](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.MethodResponse.html)<!-- -->.
 
 Marks the following response headers included,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cdk2-cors-utils",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cdk2-cors-utils",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-documenter": "^7.17.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdk2-cors-utils",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "CORS utilities for CDK v2",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/src/allow-cors.ts
+++ b/src/allow-cors.ts
@@ -28,6 +28,9 @@ const ALL_METHODS = `'${apigateway.Cors.ALL_METHODS.join(',')}'`;
  *
  * @remarks
  *
+ * This function accepts any subclass `T` of
+ * {@link https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.IntegrationResponse.html | aws_apigateway.IntegrationResponse}.
+ *
  * Configures the following response headers,
  *
  * - `Access-Control-Allow-Origin`: `*`
@@ -47,9 +50,9 @@ const ALL_METHODS = `'${apigateway.Cors.ALL_METHODS.join(',')}'`;
  *   `responses` with updated
  *   {@link https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.IntegrationResponse.html#responseparameters | responseParameters}.
  */
-export function makeIntegrationResponsesAllowCors(
-  responses: apigateway.IntegrationResponse[],
-): apigateway.IntegrationResponse[] {
+export function makeIntegrationResponsesAllowCors<T extends apigateway.IntegrationResponse>(
+  responses: T[],
+): T[] {
   responses = setResponseParameters(responses, ALLOW_ORIGIN, ALL_ORIGINS);
   responses = setResponseParameters(responses, ALLOW_HEADERS, DEFAULT_HEADERS);
   responses = setResponseParameters(responses, ALLOW_METHODS, ALL_METHODS);
@@ -62,6 +65,9 @@ export function makeIntegrationResponsesAllowCors(
  * @beta
  *
  * @remarks
+ *
+ * This function accepts any subclass `T` of
+ * {@link https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.MethodResponse.html | aws_apigateway.MethodResponse }.
  *
  * Marks the following response headers included,
  *
@@ -80,9 +86,9 @@ export function makeIntegrationResponsesAllowCors(
  *   `responses` with updated
  *   {@link https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_apigateway.MethodResponse.html#responseparameters | responseParameters}.
  */
-export function makeMethodResponsesAllowCors(
-  responses: apigateway.MethodResponse[],
-): apigateway.MethodResponse[] {
+export function makeMethodResponsesAllowCors<T extends apigateway.MethodResponse>(
+  responses: T[],
+): T[] {
   responses = setResponseParameters(responses, ALLOW_ORIGIN, true);
   responses = setResponseParameters(responses, ALLOW_HEADERS, true);
   responses = setResponseParameters(responses, ALLOW_METHODS, true);


### PR DESCRIPTION
`makeIntegrationResponsesAllowCors` and `makeMethodResponsesAllowCors` accept any subclass of `IntegrationResponse` and `MethodResponse` respectively.

- close #2