### PR TITLE
Misc updates

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -18,7 +18,7 @@ permissions:
   packages: write
 
 env:
-  node-version: 22
+  node-version: 24
   pnpm-version: 10
 
 jobs:
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get short commit hash
         id: commit-hash
@@ -55,7 +55,7 @@ jobs:
           version: ${{ env.pnpm-version }}
 
       - name: Setup Node.js ${{ env.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.node-version }}
           cache: pnpm

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "rimraf dist && tsc",
     "doc": "run-s build && api-extractor run --local && api-documenter markdown --input-folder temp --output-folder api-docs/markdown",
+    "type-check": "tsc --noEmit",
     "prepare": "run-s build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
- Adds `type-check` script
- Bumps Node.js version of the GitHub Actions runner → 24
- Bumps `actions/checkout` and `actions/setup-node`