### PR TITLE
Fix: missing --tag for publish

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -69,4 +69,5 @@ jobs:
       - name: Build and publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
-        run: pnpm publish --no-git-checks
+          DEV_PACKAGE_TAG: dev-${{ steps.package-info.outputs.version }}-${{ steps.commit-hash.outputs.short-commit-hash }}
+        run: pnpm publish --no-git-checks --tag $DEV_PACKAGE_TAG


### PR DESCRIPTION
Intends to fix the issue that `pnpm publish` failed with an error about missing `--tag` option:
>  npm error You must specify a tag using --tag when publishing a prerelease version.

Appends the `--tag` option to the `pnpm publish` command.